### PR TITLE
Task1 Federico Nuñez Frau

### DIFF
--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -2,7 +2,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
-#define SLEEP_TIME_MS 1000
+#define SLEEP_TIME_MS 333
 
 /* The devicetree node identifier for the "led0" alias. */
 #define LED_NODE DT_ALIAS(led0)

--- a/west.yml
+++ b/west.yml
@@ -8,7 +8,5 @@ manifest:
       import:
         name-allowlist:
           - cmsis_6
-          - hal_nxp
           - hal_stm32
-          - hal_nordic
         path-prefix: deps


### PR DESCRIPTION
@MFranches  y @marszald : Los arrobo en este comentario porque es la única forma que encuentro para agregarlos como reviewers. Disculpen si no es la forma correcta de hacerlo. También tuve que crear la merge request hacia el base repository y no hacia el que forkee yo porque sino github no me permite arrobarlos en este comentario.

1_ Se inicializó el workspace usando:
west init -m https://github.com/Federiconunezfrau/zephyr-course

Esto inicializó el west workspace, clonó el repositorio zephyr-course en la carpeta del workspace y modificó el archivo .west/config para que se utilice el manifest del repositorio zephyr-course.

2_ Se modificó el manifest manualmente para eliminar los imports de hal_nxp y hal_nordic, ya que la placa sobre la que estoy trabajando es STM32 y estos proyectos no serían necesarios en mi caso. Luego se ejecutó west update para actualizar el workspace de acuerdo al manifest.

3_ Para poder buildear se instaló la versión 0.17.4 de la SDK de Zephyr. Esto fue necesario porque la versión de Zephyr que indica el manifest es 4.2.0 y la versión de la SDK que tenía instalada, 1.0.0, no son compatibles. Para esto se usó la matrix con las compatibilidades entre las versiones de Zephyr y  las versiones de la SDK. Para instalar la versión de la SDK se ejecutó el comando:
west sdk install --version 0.17.4

4_ Se buildeó y flasheó con:
west build -p always -b nucleo_f103rb zephyr-course/app
west flash

5_ Se verificó que el LED parpadea cada 1 segundo y que por el puerto serie se imprimen mensajes con el siguiente formato:

*** Booting Zephyr OS build v4.2.0 ***
[00:00:00.000,000] <inf> main: LED state: OFF
[00:00:01.000,000] <inf> main: LED state: ON
[00:00:02.000,000] <inf> main: LED state: OFF

6_ Se modificó la macro SLEEP_TIME_MS para que tenga el valor 333 . Se volvió a buildear y flashear.
